### PR TITLE
Remove SleeplessOne1917 from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dessalines @SleeplessOne1917 @jim-taylor-business
+* @dessalines @jim-taylor-business


### PR DESCRIPTION
I've been doing a poor job at cooperating and can only see myself becoming more of a problem in the future. To prevent myself from hindering this project more than I already am, I am removing myself from the CODEOWNERS file.

If you still want me to contribute, I could always fork this repo and make PRs like any other contributor, but I am clearly not to be trusted with maintainer privileges. 