### PR TITLE
Remove jim-taylor-business from codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dessalines @SleeplessOne1917 @jim-taylor-business
+* @dessalines @SleeplessOne1917


### PR DESCRIPTION
Hasn't done any PRs in a long time anyway, but they're always welcome back.