### PR TITLE
Make translations reactive

### DIFF
--- a/src/ui/components/common/content_actions.rs
+++ b/src/ui/components/common/content_actions.rs
@@ -14,7 +14,7 @@ use crate::{
 use hide_post_button::HidePostButton;
 use lemmy_client::lemmy_api_common::lemmy_db_schema::source::person::Person;
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::{ActionForm, A};
 use report_button::ReportButton;
 use tailwind_fuse::tw_join;
@@ -48,9 +48,9 @@ where
   let block_user_action = create_block_user_action();
 
   let save_content_label = if matches!(post_or_comment_id, PostOrCommentId::Post(_)) {
-    tr!("save-post")
+    move_tr!("save-post")
   } else {
-    tr!("save-comment")
+    move_tr!("save-comment")
   };
   let save_icon = Signal::derive(move || {
     if saved.get() {
@@ -59,7 +59,7 @@ where
       IconType::Save
     }
   });
-  let crosspost_label = tr!("crosspost");
+  let crosspost_label = move_tr!("crosspost");
 
   // See https://book.leptos.dev/interlude_projecting_children.html
   let creator_stored = store_value(creator.clone());
@@ -67,12 +67,12 @@ where
   view! {
     <Fedilink href=ap_id.to_string() />
     <Show when=move || user_is_logged_in.get()>
-      <ActionForm action=save_action class="flex items-center" clone:save_content_label>
+      <ActionForm action=save_action class="flex items-center">
         <input type="hidden" name="id" value=post_or_comment_id.get_id() />
         <input type="hidden" name="save" value=move || (!saved.get()).to_str() />
         <button
           type="submit"
-          title=save_content_label.clone()
+          title=save_content_label
           aria-label=save_content_label
 
           class=move || {
@@ -93,8 +93,8 @@ where
               view! {
                 <A
                   href="/create_post"
-                  attr:title=crosspost_label.clone()
-                  attr:aria-label=crosspost_label.clone()
+                  attr:title=crosspost_label
+                  attr:aria-label=crosspost_label
                 >
                   <Icon icon=IconType::Crosspost />
                 </A>
@@ -125,7 +125,7 @@ where
                 <button class="text-xs whitespace-nowrap" type="submit">
                   <Icon icon=IconType::Block class="inline-block" />
                   " "
-                  {tr!("block-user")}
+                  {move_tr!("block-user")}
                 </button>
               </ActionForm>
             </li>

--- a/src/ui/components/common/content_actions.rs
+++ b/src/ui/components/common/content_actions.rs
@@ -91,11 +91,7 @@ where
       {(matches!(post_or_comment_id, PostOrCommentId::Post(_)))
           .then(|| {
               view! {
-                <A
-                  href="/create_post"
-                  attr:title=crosspost_label
-                  attr:aria-label=crosspost_label
-                >
+                <A href="/create_post" attr:title=crosspost_label attr:aria-label=crosspost_label>
                   <Icon icon=IconType::Crosspost />
                 </A>
               }

--- a/src/ui/components/common/content_actions/report_button.rs
+++ b/src/ui/components/common/content_actions/report_button.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use lemmy_client::lemmy_api_common::lemmy_db_schema::source::person::Person;
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 
 fn report_content<'a>(creator: &'a Person, post_or_comment_id: PostOrCommentId) {
   let set_report_modal_data = expect_context::<WriteSignal<ReportModalData>>();
@@ -24,9 +24,9 @@ fn report_content<'a>(creator: &'a Person, post_or_comment_id: PostOrCommentId) 
 #[component]
 pub fn ReportButton<'a>(creator: &'a Person, post_or_comment_id: PostOrCommentId) -> impl IntoView {
   let report_content_label = if matches!(post_or_comment_id, PostOrCommentId::Comment(_)) {
-    tr!("report-comment")
+    move_tr!("report-comment")
   } else {
-    tr!("report-post")
+    move_tr!("report-post")
   };
   let creator_stored = store_value(creator.clone());
   let onclick = move |_| report_content(&creator_stored.get_value(), post_or_comment_id);

--- a/src/ui/components/common/fedilink.rs
+++ b/src/ui/components/common/fedilink.rs
@@ -1,15 +1,15 @@
 use crate::ui::components::common::icon::{Icon, IconType};
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 
 #[component]
 pub fn Fedilink(#[prop(into)] href: TextProp) -> impl IntoView {
   // Need to make this a variable since using a literal makes leptos expect a format string
   let class = "[@media(hover:hover){&:hover}]:animate-color-cycle active:animate-color-cycle focus:animate-color-cycle cursor-pointer";
 
-  let label = tr!("fedilink-label");
+  let label = move_tr!("fedilink-label");
   view! {
-    <a href=href class=class title=label.clone() aria-label=label>
+    <a href=href class=class title=label aria-label=label>
       <Icon icon=IconType::Fediverse />
     </a>
   }

--- a/src/ui/components/common/vote_buttons.rs
+++ b/src/ui/components/common/vote_buttons.rs
@@ -7,7 +7,7 @@ use crate::{
   },
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::ActionForm;
 use tailwind_fuse::{
   AsTailwindClass,
@@ -68,7 +68,7 @@ where
               )
           }
 
-          title=tr!("upvote")
+          title=move_tr!("upvote")
           disabled=move || !user_is_logged_in.get() || vote_action.pending().get()
         >
 
@@ -92,7 +92,7 @@ where
               )
           }
 
-          title=tr!("downvote")
+          title=move_tr!("downvote")
 
           disabled=move || !user_is_logged_in.get() || vote_action.pending().get()
         >

--- a/src/ui/components/communities/communities_page.rs
+++ b/src/ui/components/communities/communities_page.rs
@@ -1,11 +1,11 @@
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 
 #[component]
 pub fn CommunitiesPage() -> impl IntoView {
   view! {
     <main class="mx-auto">
-      <h2 class="p-6 text-4xl">{tr!("communities")}</h2>
+      <h2 class="p-6 text-4xl">{move_tr!("communities")}</h2>
     </main>
   }
 }

--- a/src/ui/components/home/home_page.rs
+++ b/src/ui/components/home/home_page.rs
@@ -12,7 +12,7 @@ use lemmy_client::lemmy_api_common::{
   post::GetPosts,
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 
 #[component]
 pub fn HomePage() -> impl IntoView {
@@ -36,11 +36,11 @@ pub fn HomePage() -> impl IntoView {
     <div class="flex lg:container mx-auto mt-4 mb-1 lg:gap-12 h-fit lg:h-full">
       <main class="basis-full lg:basis-[65%] xl:basis-3/4 flex flex-col mx-2.5 lg:mx-0 h-fit lg:h-full">
         <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 border-b-4 border-base-300 rounded-b-md">
-          <h1 class="text-4xl font-bold text-nowrap">{tr!("home-feed")}</h1>
+          <h1 class="text-4xl font-bold text-nowrap">{move_tr!("home-feed")}</h1>
           {filter_bar}
         </div>
-        <Suspense fallback=|| tr!("loading")>
-          <ErrorBoundary fallback=|_| { tr!("could-not-load-posts") }>
+        <Suspense fallback=|| move_tr!("loading")>
+          <ErrorBoundary fallback=|_| { move_tr!("could-not-load-posts") }>
             <Unpack item=posts let:posts>
               <PostListings posts=posts />
             </Unpack>

--- a/src/ui/components/home/site_summary.rs
+++ b/src/ui/components/home/site_summary.rs
@@ -7,12 +7,12 @@ use crate::{
   utils::derive_query_signal,
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::A;
 use si_format::Formattable;
 
 #[component]
-fn UserStatRow(count: i64, text: String) -> impl IntoView {
+fn UserStatRow(count: i64, text: Signal<String>) -> impl IntoView {
   view! {
     <tr class="*:p-2.5 [&:not(:first-child)]:border-t-2 [&:not(:first-child)]:border-accent">
       <td class="text-xs font-semibold">{text}</td>
@@ -72,11 +72,11 @@ pub fn SiteSummary() -> impl IntoView {
       .collect::<Vec<_>>()
   });
 
-  let today = StoredValue::new(tr!("today"));
-  let past_week = StoredValue::new(tr!("past-week"));
-  let past_month = StoredValue::new(tr!("past-month"));
-  let past_6_months = StoredValue::new(tr!("past-6-months"));
-  let all_time = StoredValue::new(tr!("all-time"));
+  let today = move_tr!("today");
+  let past_week = move_tr!("past-week");
+  let past_month = move_tr!("past-month");
+  let past_6_months = move_tr!("past-6-months");
+  let all_time = move_tr!("all-time");
 
   view! {
     <div class="card w-full mb-3 bg-base-200">
@@ -90,7 +90,7 @@ pub fn SiteSummary() -> impl IntoView {
           </Unpack>
           <section aria-labelledby="instance-stats-heading" class="my-4">
             <h3 id="instance-stats-heading" class="text-2xl font-bold mb-2">
-              {tr!("instance-stats")}
+              {move_tr!("instance-stats")}
             </h3>
             <Unpack item=counts let:counts>
               <div class="font-semibold flex flex-wrap *:m-1.5">
@@ -98,43 +98,43 @@ pub fn SiteSummary() -> impl IntoView {
                   <Icon icon=IconType::Posts size=IconSize::Large class="inline" />
                   {counts.posts.si_format().to_string()}
                   " "
-                  <span class="text-sm">{tr!("posts")}</span>
+                  <span class="text-sm">{move_tr!("posts")}</span>
                 </div>
                 <div>
                   <Icon icon=IconType::Comments size=IconSize::Large class="inline" />
                   {counts.comments.si_format().to_string()}
                   " "
-                  <span class="text-sm">{tr!("comments")}</span>
+                  <span class="text-sm">{move_tr!("comments")}</span>
                 </div>
               </div>
               <table class="w-full mt-3 table shadow-lg">
                 <caption class="text-lg font-semibold whitespace-nowrap align-middle text-start mb-2">
                   <Icon icon=IconType::Users size=IconSize::Large class="inline me-2" />
-                  {tr!("active-users")}
+                  {move_tr!("active-users")}
                 </caption>
                 <thead>
                   <tr class="font-extrabold text-sm bg-base-300 *:p-3">
                     <th class="text-start" scope="col">
-                      {tr!("time-frame")}
+                      {move_tr!("time-frame")}
                     </th>
                     <th class="text-center" scope="col">
-                      {tr!("count")}
+                      {move_tr!("count")}
                     </th>
                   </tr>
                 </thead>
                 <tbody class="bg-base-100">
-                  <UserStatRow text=today.get_value() count=counts.users_active_day />
-                  <UserStatRow text=past_week.get_value() count=counts.users_active_week />
-                  <UserStatRow text=past_month.get_value() count=counts.users_active_month />
-                  <UserStatRow text=past_6_months.get_value() count=counts.users_active_month />
-                  <UserStatRow text=all_time.get_value() count=counts.users_active_month />
+                  <UserStatRow text=today count=counts.users_active_day />
+                  <UserStatRow text=past_week count=counts.users_active_week />
+                  <UserStatRow text=past_month count=counts.users_active_month />
+                  <UserStatRow text=past_6_months count=counts.users_active_month />
+                  <UserStatRow text=all_time count=counts.users_active_month />
                 </tbody>
               </table>
             </Unpack>
           </section>
           <section aria-labelledby="instances-admins-heading">
             <h3 id="instance-admins-heading" class="text-2xl font-bold mb-2">
-              {tr!("admins")}
+              {move_tr!("admins")}
             </h3>
             <ul class="flex flex-wrap gap-2 my-4">
               <Unpack item=admins let:admins>

--- a/src/ui/components/layouts/base_layout/mobile_nav.rs
+++ b/src/ui/components/layouts/base_layout/mobile_nav.rs
@@ -1,26 +1,26 @@
 use crate::ui::components::common::icon::{Icon, IconType};
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::*;
 
 #[component]
 pub fn MobileNav() -> impl IntoView {
   view! {
     <nav
-      aria-label=tr!("mobile-nav")
+      aria-label=move_tr!("mobile-nav")
       class="btm-nav w-full md:hidden border-t border-neutral text-xs"
     >
-      <NavLink href="/" icon=IconType::Home text=tr!("home") />
-      <NavLink href="/communities" icon=IconType::Communities text=tr!("communities") />
-      <NavLink href="/search" icon=IconType::Search text=tr!("search") />
-      <NavLink href="/saved" icon=IconType::Saved text=tr!("saved") />
-      <NavLink href="/" icon=IconType::Profile text=tr!("profile") />
+      <NavLink href="/" icon=IconType::Home text=move_tr!("home") />
+      <NavLink href="/communities" icon=IconType::Communities text=move_tr!("communities") />
+      <NavLink href="/search" icon=IconType::Search text=move_tr!("search") />
+      <NavLink href="/saved" icon=IconType::Saved text=move_tr!("saved") />
+      <NavLink href="/" icon=IconType::Profile text=move_tr!("profile") />
     </nav>
   }
 }
 
 #[component]
-fn NavLink(href: &'static str, icon: IconType, text: String) -> impl IntoView {
+fn NavLink(href: &'static str, icon: IconType, text: Signal<String>) -> impl IntoView {
   // TODO: Apply active to aria-current=page once the unusual cargo-leptos bug is resolved
   view! {
     <A href=href>

--- a/src/ui/components/layouts/base_layout/side_nav.rs
+++ b/src/ui/components/layouts/base_layout/side_nav.rs
@@ -31,9 +31,17 @@ pub fn SideNav() -> impl IntoView {
           icon=IconType::Documentation
           text=move_tr!("documentation")
         />
-        <NavLink href="https://github.com/LemmyNet" icon=IconType::Code text=move_tr!("source-code") />
+        <NavLink
+          href="https://github.com/LemmyNet"
+          icon=IconType::Code
+          text=move_tr!("source-code")
+        />
         <NavLink href="https://join-lemmy.org/" icon=IconType::Info text=move_tr!("about") />
-        <NavLink href="https://join-lemmy.org/donate" icon=IconType::Donate text=move_tr!("donate") />
+        <NavLink
+          href="https://join-lemmy.org/donate"
+          icon=IconType::Donate
+          text=move_tr!("donate")
+        />
       </ul>
     </section>
   }

--- a/src/ui/components/layouts/base_layout/side_nav.rs
+++ b/src/ui/components/layouts/base_layout/side_nav.rs
@@ -1,46 +1,46 @@
 use crate::ui::components::common::icon::{Icon, IconType};
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::A;
 
 #[component]
 pub fn SideNav() -> impl IntoView {
   view! {
-    <section aria-label=tr!("main-nav-links")>
+    <section aria-label=move_tr!("main-nav-links")>
       <ul>
-        <NavLink href="/create_post" icon=IconType::CreatePost text=tr!("create-post") />
+        <NavLink href="/create_post" icon=IconType::CreatePost text=move_tr!("create-post") />
         <NavLink
           href="/create_community"
           icon=IconType::CreateCommunity
-          text=tr!("create-community")
+          text=move_tr!("create-community")
         />
-        <NavLink href="/communities" icon=IconType::Communities text=tr!("communities") />
-        <NavLink href="/search" icon=IconType::Search text=tr!("search") />
-        <NavLink href="/modlog" icon=IconType::Modlog text=tr!("modlog") />
-        <NavLink href="/instances" icon=IconType::Instances text=tr!("instances") />
-        <NavLink href="/legal" icon=IconType::Legal text=tr!("legal") />
+        <NavLink href="/communities" icon=IconType::Communities text=move_tr!("communities") />
+        <NavLink href="/search" icon=IconType::Search text=move_tr!("search") />
+        <NavLink href="/modlog" icon=IconType::Modlog text=move_tr!("modlog") />
+        <NavLink href="/instances" icon=IconType::Instances text=move_tr!("instances") />
+        <NavLink href="/legal" icon=IconType::Legal text=move_tr!("legal") />
       </ul>
     </section>
     <section aria-labelledby="lemmy-resources-label" class="mt-auto">
       <div id="lemmy-resources-label" class="font-medium mb-1">
-        {tr!("lemmy-resources")}
+        {move_tr!("lemmy-resources")}
       </div>
       <ul>
         <NavLink
           href="https://join-lemmy.org/docs/en/index.html"
           icon=IconType::Documentation
-          text=tr!("documentation")
+          text=move_tr!("documentation")
         />
-        <NavLink href="https://github.com/LemmyNet" icon=IconType::Code text=tr!("source-code") />
-        <NavLink href="https://join-lemmy.org/" icon=IconType::Info text=tr!("about") />
-        <NavLink href="https://join-lemmy.org/donate" icon=IconType::Donate text=tr!("donate") />
+        <NavLink href="https://github.com/LemmyNet" icon=IconType::Code text=move_tr!("source-code") />
+        <NavLink href="https://join-lemmy.org/" icon=IconType::Info text=move_tr!("about") />
+        <NavLink href="https://join-lemmy.org/donate" icon=IconType::Donate text=move_tr!("donate") />
       </ul>
     </section>
   }
 }
 
 #[component]
-fn NavLink(href: &'static str, icon: IconType, #[prop(into)] text: TextProp) -> impl IntoView {
+fn NavLink(href: &'static str, icon: IconType, text: Signal<String>) -> impl IntoView {
   view! {
     <li>
       <A

--- a/src/ui/components/layouts/base_layout/top_nav/auth_dropdown.rs
+++ b/src/ui/components/layouts/base_layout/top_nav/auth_dropdown.rs
@@ -8,7 +8,7 @@ use crate::{
   utils::{derive_query_signal, derive_user_is_logged_in},
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::{ActionForm, A};
 
 #[component]
@@ -34,7 +34,7 @@ pub fn AuthDropdown() -> impl IntoView {
 
   view! {
     <nav class="hidden md:block">
-      <ul aria-label=tr!("authentication-nav") class="flex items-center gap-x-2">
+      <ul aria-label=move_tr!("authentication-nav") class="flex items-center gap-x-2">
         <Show
           when=move || user_is_logged_in.get()
 
@@ -42,13 +42,13 @@ pub fn AuthDropdown() -> impl IntoView {
               view! {
                 <li>
                   <A href="/login" class="btn btn-ghost transition duration-500">
-                    {tr!("login")}
+                    {move_tr!("login")}
                   </A>
                 </li>
                 <li>
                   <A href="/signup" class="btn btn-primary transition duration-500">
 
-                    {tr!("signup")}
+                    {move_tr!("signup")}
                   </A>
                 </li>
               }
@@ -59,7 +59,7 @@ pub fn AuthDropdown() -> impl IntoView {
             <li>
               <details
                 class="dropdown dropdown-end group"
-                aria-label=tr!("logged-in-user-dropdown")
+                aria-label=move_tr!("logged-in-user-dropdown")
               >
                 <summary class="btn">
 
@@ -92,16 +92,16 @@ pub fn AuthDropdown() -> impl IntoView {
                             .0
                             .as_str();
                         format!("/u/{name}")
-                    }>{tr!("profile")}</A>
+                    }>{move_tr!("profile")}</A>
                   </li>
                   <li>
-                    <A href="/settings">{tr!("settings")}</A>
+                    <A href="/settings">{move_tr!("settings")}</A>
                   </li>
                   <div class="divider my-0"></div>
                   <li>
                     <ActionForm action=logout_action class="p-0">
                       <button type="submit" class="p-2.5">
-                        {tr!("logout")}
+                        {move_tr!("logout")}
                       </button>
                     </ActionForm>
                   </li>

--- a/src/ui/components/layouts/base_layout/top_nav/notification_bell.rs
+++ b/src/ui/components/layouts/base_layout/top_nav/notification_bell.rs
@@ -4,7 +4,7 @@ use crate::{
   utils::derive_user_is_logged_in,
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::A;
 
 #[component]
@@ -15,7 +15,7 @@ pub fn NotificationBell() -> impl IntoView {
   view! {
     <Show when=move || user_is_logged_in.get()>
       <A href="/inbox" class="me-2">
-        <span title=tr!("unread-messages")>
+        <span title=move_tr!("unread-messages")>
           <Icon icon=IconType::Notifications />
         </span>
       </A>

--- a/src/ui/components/layouts/base_layout/top_nav/theme_select.rs
+++ b/src/ui/components/layouts/base_layout/top_nav/theme_select.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use html::Details;
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 use leptos_router::ActionForm;
 #[cfg(not(feature = "ssr"))]
 use leptos_use::on_click_outside;
@@ -33,7 +33,7 @@ pub fn ThemeSelect() -> impl IntoView {
 
   view! {
     <details class="dropdown dropdown-end group" node_ref=dropdown_node_ref>
-      <summary class="btn btn-circle btn-ghost relative" aria-label=tr!("theme")>
+      <summary class="btn btn-circle btn-ghost relative" aria-label=move_tr!("theme")>
         <Icon class="absolute left-1 inset-y-auto" icon=IconType::Theme />
         <Icon
           class="absolute right-2.5 bottom-1 group-open:rotate-180 transition-transform"
@@ -46,7 +46,7 @@ pub fn ThemeSelect() -> impl IntoView {
           <ActionForm action=theme_action class="p-0">
             <input type="hidden" name="theme" value=Theme::Dark />
             <button type="submit" class="p-2.5">
-              {tr!("dark")}
+              {move_tr!("dark")}
             </button>
           </ActionForm>
         </li>
@@ -54,7 +54,7 @@ pub fn ThemeSelect() -> impl IntoView {
           <ActionForm action=theme_action class="p-0">
             <input type="hidden" name="theme" value=Theme::Light />
             <button type="submit" class="p-2.5">
-              {tr!("light")}
+              {move_tr!("light")}
             </button>
           </ActionForm>
         </li>
@@ -62,7 +62,7 @@ pub fn ThemeSelect() -> impl IntoView {
           <ActionForm action=theme_action class="p-0">
             <input type="hidden" name="theme" value=Theme::Retro />
             <button type="submit" class="p-2.5">
-              {tr!("retro")}
+              {move_tr!("retro")}
             </button>
           </ActionForm>
         </li>

--- a/src/ui/components/layouts/filter_bar_layout/filter_bar.rs
+++ b/src/ui/components/layouts/filter_bar_layout/filter_bar.rs
@@ -8,7 +8,7 @@ use crate::ui::components::{
 };
 use lemmy_client::lemmy_api_common::lemmy_db_schema::{ListingType, SortType};
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::move_tr;
 
 #[component]
 pub fn FilterBar(
@@ -32,24 +32,24 @@ pub fn FilterBar(
   view! {
     <div class="mb-4 flex flex-wrap gap-3">
       <div class="join">
-        <button class="btn join-item btn-active">{tr!("posts")}</button>
-        <button class="btn join-item btn-disabled">{tr!("comments")}</button>
+        <button class="btn join-item btn-active">{move_tr!("posts")}</button>
+        <button class="btn join-item btn-disabled">{move_tr!("comments")}</button>
       </div>
       <div class="join">
         <ListingTypeLink listing_type=listing_type link_listing_type=ListingType::Subscribed>
-          {tr!("subscribed")}
+          {move_tr!("subscribed")}
         </ListingTypeLink>
         <ListingTypeLink listing_type=listing_type link_listing_type=ListingType::Local>
-          {tr!("local")}
+          {move_tr!("local")}
         </ListingTypeLink>
         <ListingTypeLink listing_type=listing_type link_listing_type=ListingType::All>
-          {tr!("all")}
+          {move_tr!("all")}
         </ListingTypeLink>
       </div>
       <details class="dropdown dropdown-end group">
         <summary class="btn">
           <span class="text-nowrap leading-loose">
-            {tr!("sort-type")}" "
+            {move_tr!("sort-type")}" "
             <Icon
               class="align-bottom inline group-open:rotate-180 transition-transform"
               icon=IconType::DropdownCaret
@@ -60,13 +60,13 @@ pub fn FilterBar(
         </summary>
         <menu class="*:p-0 p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box">
           <SortTypeLink sort_type=sort_type link_sort_type=SortType::Active>
-            {tr!("active")}
+            {move_tr!("active")}
           </SortTypeLink>
           <SortTypeLink sort_type=sort_type link_sort_type=SortType::Hot>
-            {tr!("hot")}
+            {move_tr!("hot")}
           </SortTypeLink>
           <SortTypeLink sort_type=sort_type link_sort_type=SortType::New>
-            {tr!("new")}
+            {move_tr!("new")}
           </SortTypeLink>
         </menu>
       </details>

--- a/src/ui/components/login/login_form.rs
+++ b/src/ui/components/login/login_form.rs
@@ -4,7 +4,7 @@ use crate::{
   ui::components::common::text_input::{InputType, TextInput},
 };
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::{move_tr, tr};
 use leptos_router::ActionForm;
 
 #[component]
@@ -31,7 +31,7 @@ pub fn LoginForm() -> impl IntoView {
       <TextInput
         id="username"
         name="username_or_email"
-        label=tr!("username")
+        label=move || tr!("username")
         required=true
         min_length=3
       />
@@ -39,14 +39,14 @@ pub fn LoginForm() -> impl IntoView {
       <TextInput
         id="password"
         name="password"
-        label=tr!("password")
+        label=move || tr!("password")
         input_type=InputType::Password
         pattern=".{10,60}"
         required=true
       />
 
       <button class="btn btn-lg" type="submit">
-        {tr!("login")}
+        {move_tr!("login")}
       </button>
     </ActionForm>
   }

--- a/src/ui/components/modals/report_modal.rs
+++ b/src/ui/components/modals/report_modal.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use html::Dialog;
 use leptos::*;
-use leptos_fluent::tr;
+use leptos_fluent::{move_tr, tr};
 use leptos_router::ActionForm;
 
 #[component]
@@ -60,15 +60,15 @@ fn ReportForm(
       required=true
       id="report_reason_id"
       name="reason"
-      label=tr!("reason")
+      label=move || tr!("reason")
       autofocus=true
     />
     <div class="modal-action">
       <button formmethod="dialog" formnovalidate=true class="btn btn-outline">
-        {tr!("cancel")}
+        {move_tr!("cancel")}
       </button>
       <button type="submit" class="btn btn-error">
-        {tr!("submit-report")}
+        {move_tr!("submit-report")}
       </button>
     </div>
   }


### PR DESCRIPTION
It turns out all translations, even those using the `tr!` macro, are meant to be used reactively. Not using them reactively results in a bunch of these warnings in the browser console:

```
At /home/insomnia/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos-fluent-0.1.8/src/lib.rs:580:33, you access a signal or memo (defined at src/lib.rs:50:3) outside a reactive tracking context. This might mean your app is not responding to changes in signal values in the way you expect.

Here’s how to fix it:

1. If this is inside a `view!` macro, make sure you are passing a function, not a value.
  ❌ NO  <p>{x.get() * 2}</p>
  ✅ YES <p>{move || x.get() * 2}</p>

2. If it’s in the body of a component, try wrapping this access in a closure: 
  ❌ NO  let y = x.get() * 2
  ✅ YES let y = move || x.get() * 2.

3. If you’re *trying* to access the value without tracking, use `.get_untracked()` or `.with_untracked()` instead.
```

Refer to [this issue in the leptos-fluent repo](https://github.com/mondeja/leptos-fluent/issues/198) for more info.