### PR TITLE
Scroll tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,9 +3917,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,9 +498,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "bytestring"
@@ -551,9 +551,9 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
 name = "cc"
-version = "1.1.19"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2505,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -3708,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -3902,9 +3902,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]

--- a/end2end/package.json
+++ b/end2end/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.47.1",
+    "@playwright/test": "^1.47.2",
     "@types/node": "^22.5.5",
     "typescript": "^5.6.2"
   }

--- a/end2end/pnpm-lock.yaml
+++ b/end2end/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.47.1
-        version: 1.47.1
+        specifier: ^1.47.2
+        version: 1.47.2
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
@@ -20,8 +20,8 @@ importers:
 
 packages:
 
-  '@playwright/test@1.47.1':
-    resolution: {integrity: sha512-dbWpcNQZ5nj16m+A5UNScYx7HX5trIy7g4phrcitn+Nk83S32EBX/CLU4hiF4RGKX/yRc93AAqtfaXB7JWBd4Q==}
+  '@playwright/test@1.47.2':
+    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -33,13 +33,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  playwright-core@1.47.1:
-    resolution: {integrity: sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==}
+  playwright-core@1.47.2:
+    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.47.1:
-    resolution: {integrity: sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==}
+  playwright@1.47.2:
+    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -53,9 +53,9 @@ packages:
 
 snapshots:
 
-  '@playwright/test@1.47.1':
+  '@playwright/test@1.47.2':
     dependencies:
-      playwright: 1.47.1
+      playwright: 1.47.2
 
   '@types/node@22.5.5':
     dependencies:
@@ -64,11 +64,11 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  playwright-core@1.47.1: {}
+  playwright-core@1.47.2: {}
 
-  playwright@1.47.1:
+  playwright@1.47.2:
     dependencies:
-      playwright-core: 1.47.1
+      playwright-core: 1.47.2
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@savvywombat/tailwindcss-grid-areas": "^4.0.0",
     "daisyui": "^4.12.10",
     "prettier": "^3.3.3",
-    "tailwindcss": "^3.4.11"
+    "tailwindcss": "^3.4.12"
   },
   "scripts": {
     "fmt": "prettier . --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@savvywombat/tailwindcss-grid-areas':
         specifier: ^4.0.0
-        version: 4.0.0(tailwindcss@3.4.11)
+        version: 4.0.0(tailwindcss@3.4.12)
       daisyui:
         specifier: ^4.12.10
         version: 4.12.10(postcss@8.4.47)
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       tailwindcss:
-        specifier: ^3.4.11
-        version: 3.4.11
+        specifier: ^3.4.12
+        version: 3.4.12
 
 packages:
 
@@ -428,8 +428,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwindcss@3.4.11:
-    resolution: {integrity: sha512-qhEuBcLemjSJk5ajccN9xJFtM/h0AVCPaA6C92jNP+M2J8kX+eMJHI7R2HFKUvvAsMpcfLILMCFYSeDwpMmlUg==}
+  tailwindcss@3.4.12:
+    resolution: {integrity: sha512-Htf/gHj2+soPb9UayUNci/Ja3d8pTmu9ONTfh4QY8r3MATTZOzmv6UYWF7ZwikEIC8okpfqmGqrmDehua8mF8w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -513,9 +513,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@savvywombat/tailwindcss-grid-areas@4.0.0(tailwindcss@3.4.11)':
+  '@savvywombat/tailwindcss-grid-areas@4.0.0(tailwindcss@3.4.12)':
     dependencies:
-      tailwindcss: 3.4.11
+      tailwindcss: 3.4.12
 
   ansi-regex@5.0.1: {}
 
@@ -838,7 +838,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.11:
+  tailwindcss@3.4.12:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
+leptosfmt -c .leptosfmt.toml src
 taplo format
 cargo +nightly fmt
 pnpm fmt
-leptosfmt -c .leptosfmt.toml src

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
-leptosfmt -c .leptosfmt.toml src
 taplo format
 cargo +nightly fmt
 pnpm fmt
+leptosfmt -c .leptosfmt.toml src

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,22 +101,22 @@ pub fn App() -> impl IntoView {
           <Route
             path="login"
             view=move || {
-                view! {
-                  <AnonymousOnlyRouteView>
-                    <LoginPage />
-                  </AnonymousOnlyRouteView>
-                }
+              view! {
+                <AnonymousOnlyRouteView>
+                  <LoginPage />
+                </AnonymousOnlyRouteView>
+              }
             }
           />
 
           <Route
             path="signup"
             view=move || {
-                view! {
-                  <AnonymousOnlyRouteView>
-                    <CommunitiesPage />
-                  </AnonymousOnlyRouteView>
-                }
+              view! {
+                <AnonymousOnlyRouteView>
+                  <CommunitiesPage />
+                </AnonymousOnlyRouteView>
+              }
             }
           />
 
@@ -147,15 +147,15 @@ fn AnonymousOnlyRouteView(children: ChildrenFn) -> impl IntoView {
       <Show
         when=move || !user_is_logged_in.get()
         fallback=move || {
-            view! {
-              <Redirect
-                path="/"
-                options=NavigateOptions {
-                    replace: true,
-                    ..Default::default()
-                }
-              />
-            }
+          view! {
+            <Redirect
+              path="/"
+              options=NavigateOptions {
+                replace: true,
+                ..Default::default()
+              }
+            />
+          }
         }
       >
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,71 +68,71 @@ pub fn App() -> impl IntoView {
   provide_context(report_modal);
 
   view! {
-    <Router set_is_routing=is_routing>
-      <RoutingProgress is_routing max_time=std::time::Duration::from_millis(250) />
+      <Router set_is_routing=is_routing>
+          <RoutingProgress is_routing max_time=std::time::Duration::from_millis(250) />
 
-      <Stylesheet id="leptos" href="/pkg/lemmy-ui-leptos.css" />
-      <Link rel="shortcut icon" href="/favicon.svg" />
+          <Stylesheet id="leptos" href="/pkg/lemmy-ui-leptos.css" />
+          <Link rel="shortcut icon" href="/favicon.svg" />
 
-      <Meta name="description" content="Lemmy-UI-Leptos." />
-      <Meta name="viewport" content="width=device-width, viewport-fit=cover" />
-      // debug where there is no visible console (mobile/live/desktop)
-      // <Script src="//cdn.jsdelivr.net/npm/eruda"/>
-      // <Script>eruda.init();</Script>
-      <Title text="Brand from env" />
-      <Body class="h-full max-h-screen flex flex-col overflow-y-hidden" />
+          <Meta name="description" content="Lemmy-UI-Leptos." />
+          <Meta name="viewport" content="width=device-width, viewport-fit=cover" />
+          // debug where there is no visible console (mobile/live/desktop)
+          // <Script src="//cdn.jsdelivr.net/npm/eruda"/>
+          // <Script>eruda.init();</Script>
+          <Title text="Brand from env" />
+          <Body class="h-full max-h-screen flex flex-col overflow-y-hidden" />
 
-      <Routes>
-        <Route path="" view=BaseLayout ssr=SsrMode::Async>
-          <Route path="/*any" view=NotFound />
+          <Routes>
+              <Route path="" view=BaseLayout ssr=SsrMode::Async>
+                  <Route path="/*any" view=NotFound />
 
-          <Route path="" view=FilterBarLayout>
-            <Route path="" view=HomePage />
-          </Route>
+                  <Route path="" view=FilterBarLayout>
+                      <Route path="" view=HomePage />
+                  </Route>
 
-          <Route path="create_post" view=CommunitiesPage />
-          <Route path="post/:id" view=PostPage />
+                  <Route path="create_post" view=CommunitiesPage />
+                  <Route path="post/:id" view=PostPage />
 
-          <Route path="search" view=CommunitiesPage />
-          <Route path="communities" view=CommunitiesPage />
-          <Route path="create_community" view=CommunitiesPage />
-          <Route path="c/:id" view=CommunitiesPage />
+                  <Route path="search" view=CommunitiesPage />
+                  <Route path="communities" view=CommunitiesPage />
+                  <Route path="create_community" view=CommunitiesPage />
+                  <Route path="c/:id" view=CommunitiesPage />
 
-          <Route
-            path="login"
-            view=move || {
-                view! {
-                  <AnonymousOnlyRouteView>
-                    <LoginPage />
-                  </AnonymousOnlyRouteView>
-                }
-            }
-          />
+                  <Route
+                      path="login"
+                      view=move || {
+                          view! {
+                              <AnonymousOnlyRouteView>
+                                  <LoginPage />
+                              </AnonymousOnlyRouteView>
+                          }
+                      }
+                  />
 
-          <Route
-            path="signup"
-            view=move || {
-                view! {
-                  <AnonymousOnlyRouteView>
-                    <CommunitiesPage />
-                  </AnonymousOnlyRouteView>
-                }
-            }
-          />
+                  <Route
+                      path="signup"
+                      view=move || {
+                          view! {
+                              <AnonymousOnlyRouteView>
+                                  <CommunitiesPage />
+                              </AnonymousOnlyRouteView>
+                          }
+                      }
+                  />
 
-          <Route path="inbox" view=CommunitiesPage />
-          <Route path="settings" view=CommunitiesPage />
-          <Route path="u/:id" view=CommunitiesPage />
-          <Route path="saved" view=CommunitiesPage />
+                  <Route path="inbox" view=CommunitiesPage />
+                  <Route path="settings" view=CommunitiesPage />
+                  <Route path="u/:id" view=CommunitiesPage />
+                  <Route path="saved" view=CommunitiesPage />
 
-          <Route path="modlog" view=CommunitiesPage />
-          <Route path="instances" view=CommunitiesPage />
-          <Route path="legal" view=CommunitiesPage />
-        </Route>
-      </Routes>
+                  <Route path="modlog" view=CommunitiesPage />
+                  <Route path="instances" view=CommunitiesPage />
+                  <Route path="legal" view=CommunitiesPage />
+              </Route>
+          </Routes>
 
-      <ReportModal dialog_ref=report_modal.0 modal_data=report_modal_data />
-    </Router>
+          <ReportModal dialog_ref=report_modal.0 modal_data=report_modal_data />
+      </Router>
   }
 }
 
@@ -143,25 +143,25 @@ fn AnonymousOnlyRouteView(children: ChildrenFn) -> impl IntoView {
   let children = StoredValue::new(children);
 
   view! {
-    <Transition>
-      <Show
-        when=move || !user_is_logged_in.get()
-        fallback=move || {
-            view! {
-              <Redirect
-                path="/"
-                options=NavigateOptions {
-                    replace: true,
-                    ..Default::default()
-                }
-              />
-            }
-        }
-      >
+      <Transition>
+          <Show
+              when=move || !user_is_logged_in.get()
+              fallback=move || {
+                  view! {
+                      <Redirect
+                          path="/"
+                          options=NavigateOptions {
+                              replace: true,
+                              ..Default::default()
+                          }
+                      />
+                  }
+              }
+          >
 
-        {children.get_value()}
-      </Show>
-    </Transition>
+              {children.get_value()}
+          </Show>
+      </Transition>
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,71 +68,71 @@ pub fn App() -> impl IntoView {
   provide_context(report_modal);
 
   view! {
-      <Router set_is_routing=is_routing>
-          <RoutingProgress is_routing max_time=std::time::Duration::from_millis(250) />
+    <Router set_is_routing=is_routing>
+      <RoutingProgress is_routing max_time=std::time::Duration::from_millis(250) />
 
-          <Stylesheet id="leptos" href="/pkg/lemmy-ui-leptos.css" />
-          <Link rel="shortcut icon" href="/favicon.svg" />
+      <Stylesheet id="leptos" href="/pkg/lemmy-ui-leptos.css" />
+      <Link rel="shortcut icon" href="/favicon.svg" />
 
-          <Meta name="description" content="Lemmy-UI-Leptos." />
-          <Meta name="viewport" content="width=device-width, viewport-fit=cover" />
-          // debug where there is no visible console (mobile/live/desktop)
-          // <Script src="//cdn.jsdelivr.net/npm/eruda"/>
-          // <Script>eruda.init();</Script>
-          <Title text="Brand from env" />
-          <Body class="h-full max-h-screen flex flex-col overflow-y-hidden" />
+      <Meta name="description" content="Lemmy-UI-Leptos." />
+      <Meta name="viewport" content="width=device-width, viewport-fit=cover" />
+      // debug where there is no visible console (mobile/live/desktop)
+      // <Script src="//cdn.jsdelivr.net/npm/eruda"/>
+      // <Script>eruda.init();</Script>
+      <Title text="Brand from env" />
+      <Body class="h-full max-h-screen flex flex-col overflow-y-hidden" />
 
-          <Routes>
-              <Route path="" view=BaseLayout ssr=SsrMode::Async>
-                  <Route path="/*any" view=NotFound />
+      <Routes>
+        <Route path="" view=BaseLayout ssr=SsrMode::Async>
+          <Route path="/*any" view=NotFound />
 
-                  <Route path="" view=FilterBarLayout>
-                      <Route path="" view=HomePage />
-                  </Route>
+          <Route path="" view=FilterBarLayout>
+            <Route path="" view=HomePage />
+          </Route>
 
-                  <Route path="create_post" view=CommunitiesPage />
-                  <Route path="post/:id" view=PostPage />
+          <Route path="create_post" view=CommunitiesPage />
+          <Route path="post/:id" view=PostPage />
 
-                  <Route path="search" view=CommunitiesPage />
-                  <Route path="communities" view=CommunitiesPage />
-                  <Route path="create_community" view=CommunitiesPage />
-                  <Route path="c/:id" view=CommunitiesPage />
+          <Route path="search" view=CommunitiesPage />
+          <Route path="communities" view=CommunitiesPage />
+          <Route path="create_community" view=CommunitiesPage />
+          <Route path="c/:id" view=CommunitiesPage />
 
-                  <Route
-                      path="login"
-                      view=move || {
-                          view! {
-                              <AnonymousOnlyRouteView>
-                                  <LoginPage />
-                              </AnonymousOnlyRouteView>
-                          }
-                      }
-                  />
+          <Route
+            path="login"
+            view=move || {
+                view! {
+                  <AnonymousOnlyRouteView>
+                    <LoginPage />
+                  </AnonymousOnlyRouteView>
+                }
+            }
+          />
 
-                  <Route
-                      path="signup"
-                      view=move || {
-                          view! {
-                              <AnonymousOnlyRouteView>
-                                  <CommunitiesPage />
-                              </AnonymousOnlyRouteView>
-                          }
-                      }
-                  />
+          <Route
+            path="signup"
+            view=move || {
+                view! {
+                  <AnonymousOnlyRouteView>
+                    <CommunitiesPage />
+                  </AnonymousOnlyRouteView>
+                }
+            }
+          />
 
-                  <Route path="inbox" view=CommunitiesPage />
-                  <Route path="settings" view=CommunitiesPage />
-                  <Route path="u/:id" view=CommunitiesPage />
-                  <Route path="saved" view=CommunitiesPage />
+          <Route path="inbox" view=CommunitiesPage />
+          <Route path="settings" view=CommunitiesPage />
+          <Route path="u/:id" view=CommunitiesPage />
+          <Route path="saved" view=CommunitiesPage />
 
-                  <Route path="modlog" view=CommunitiesPage />
-                  <Route path="instances" view=CommunitiesPage />
-                  <Route path="legal" view=CommunitiesPage />
-              </Route>
-          </Routes>
+          <Route path="modlog" view=CommunitiesPage />
+          <Route path="instances" view=CommunitiesPage />
+          <Route path="legal" view=CommunitiesPage />
+        </Route>
+      </Routes>
 
-          <ReportModal dialog_ref=report_modal.0 modal_data=report_modal_data />
-      </Router>
+      <ReportModal dialog_ref=report_modal.0 modal_data=report_modal_data />
+    </Router>
   }
 }
 
@@ -143,25 +143,25 @@ fn AnonymousOnlyRouteView(children: ChildrenFn) -> impl IntoView {
   let children = StoredValue::new(children);
 
   view! {
-      <Transition>
-          <Show
-              when=move || !user_is_logged_in.get()
-              fallback=move || {
-                  view! {
-                      <Redirect
-                          path="/"
-                          options=NavigateOptions {
-                              replace: true,
-                              ..Default::default()
-                          }
-                      />
-                  }
-              }
-          >
+    <Transition>
+      <Show
+        when=move || !user_is_logged_in.get()
+        fallback=move || {
+            view! {
+              <Redirect
+                path="/"
+                options=NavigateOptions {
+                    replace: true,
+                    ..Default::default()
+                }
+              />
+            }
+        }
+      >
 
-              {children.get_value()}
-          </Show>
-      </Transition>
+        {children.get_value()}
+      </Show>
+    </Transition>
   }
 }
 

--- a/src/ui/components/comment/comment_node.rs
+++ b/src/ui/components/comment/comment_node.rs
@@ -6,7 +6,7 @@ pub fn CommentNode(comment_view: MaybeSignal<CommentView>) -> impl IntoView {
   view! {
     <div>
       {move || {
-          format!("{} - {}", comment_view.get().creator.name, comment_view.get().comment.content)
+        format!("{} - {}", comment_view.get().creator.name, comment_view.get().comment.content)
       }}
 
     </div>

--- a/src/ui/components/common/community_listing.rs
+++ b/src/ui/components/common/community_listing.rs
@@ -15,10 +15,10 @@ pub fn CommunityListing<'a>(community: &'a Community) -> impl IntoView {
   view! {
     <div class="flex items-center gap-x-2">
       {icon
-          .map_or_else(
-              || view! { <Icon icon=IconType::Community /> },
-              |icon| view! { <img src=icon class="size-6" /> }.into_view(),
-          )} <div>
+        .map_or_else(
+          || view! { <Icon icon=IconType::Community /> },
+          |icon| view! { <img src=icon class="size-6" /> }.into_view(),
+        )} <div>
         <div class="text-sm mb-px font-medium">{&community.title}</div>
         <A href=format!("/c/{}", community.name) class="text-xs block text-secondary font-light">
           {community_apub_name}

--- a/src/ui/components/common/content_actions.rs
+++ b/src/ui/components/common/content_actions.rs
@@ -76,10 +76,10 @@ where
           aria-label=save_content_label
 
           class=move || {
-              tw_join!(
-                  "disabled:cursor-not-allowed disabled:text-neutral-content", saved.get()
+            tw_join!(
+              "disabled:cursor-not-allowed disabled:text-neutral-content", saved.get()
                       .then_some("text-accent")
-              )
+            )
           }
 
           disabled=move || save_action.pending().get()
@@ -89,13 +89,13 @@ where
         </button>
       </ActionForm>
       {(matches!(post_or_comment_id, PostOrCommentId::Post(_)))
-          .then(|| {
-              view! {
-                <A href="/create_post" attr:title=crosspost_label attr:aria-label=crosspost_label>
-                  <Icon icon=IconType::Crosspost />
-                </A>
-              }
-          })}
+        .then(|| {
+          view! {
+            <A href="/create_post" attr:title=crosspost_label attr:aria-label=crosspost_label>
+              <Icon icon=IconType::Crosspost />
+            </A>
+          }
+        })}
 
       <div class="dropdown">
         <div tabindex="0" role="button">
@@ -103,12 +103,12 @@ where
         </div>
         <menu tabindex="0" class="menu dropdown-content z-[1] bg-base-100 rounded-box shadow">
           <Show when=move || {
-              logged_in_user_id.get().map(|id| id != creator_stored.get_value().id).unwrap_or(false)
+            logged_in_user_id.get().map(|id| id != creator_stored.get_value().id).unwrap_or(false)
           }>
             {if let PostOrCommentId::Post(id) = post_or_comment_id {
-                Some(view! { <HidePostButton id=id /> })
+              Some(view! { <HidePostButton id=id /> })
             } else {
-                None
+              None
             }} <li>
               <ReportButton
                 creator=&creator_stored.get_value()

--- a/src/ui/components/common/sidebar.rs
+++ b/src/ui/components/common/sidebar.rs
@@ -87,18 +87,18 @@ pub fn Sidebar<'a>(data: &'a SidebarData) -> impl IntoView {
             </div>
 
             {if let SidebarData::Site(s) = data {
-                Some(
-                    view! {
-                      <div>
-                        <Icon icon=IconType::Communities size=IconSize::Large class="inline" />
-                        {s.counts.communities.pretty_format()}
-                        " "
-                        <span class="text-sm">{move_tr!("communities")}</span>
-                      </div>
-                    },
-                )
+              Some(
+                view! {
+                  <div>
+                    <Icon icon=IconType::Communities size=IconSize::Large class="inline" />
+                    {s.counts.communities.pretty_format()}
+                    " "
+                    <span class="text-sm">{move_tr!("communities")}</span>
+                  </div>
+                },
+              )
             } else {
-                None
+              None
             }}
           </div>
           <table class="w-full mt-3 table shadow-lg">
@@ -122,16 +122,16 @@ pub fn Sidebar<'a>(data: &'a SidebarData) -> impl IntoView {
               <UserStatRow text=past_month count=users_month />
               <UserStatRow text=past_6_months count=users_6_months />
               {match data {
-                  SidebarData::Site(s) => {
-                      view! { <UserStatRow text=all_time count=s.counts.users /> }.into_view()
+                SidebarData::Site(s) => {
+                  view! { <UserStatRow text=all_time count=s.counts.users /> }.into_view()
+                }
+                SidebarData::Community(c) => {
+                  view! {
+                    <UserStatRow text=local_subscribers count=c.counts.subscribers_local />
+                    <UserStatRow text=subscribers count=c.counts.subscribers />
                   }
-                  SidebarData::Community(c) => {
-                      view! {
-                        <UserStatRow text=local_subscribers count=c.counts.subscribers_local />
-                        <UserStatRow text=subscribers count=c.counts.subscribers />
-                      }
-                          .into_view()
-                  }
+                    .into_view()
+                }
               }}
             </tbody>
           </table>

--- a/src/ui/components/common/sidebar/team_member_card.rs
+++ b/src/ui/components/common/sidebar/team_member_card.rs
@@ -9,11 +9,11 @@ pub fn TeamMemberCard(person: Person) -> impl IntoView {
     <li class="flex-1 text-center max-w-fit rounded-lg p-3 even:bg-base-100 odd:bg-base-300 shadow-lg shadow-neutral">
       <img
         src=person
-            .avatar
-            .as_deref()
-            .map(AsRef::as_ref)
-            .map(ToOwned::to_owned)
-            .unwrap_or(DEFAULT_AVATAR_PATH.to_owned())
+          .avatar
+          .as_deref()
+          .map(AsRef::as_ref)
+          .map(ToOwned::to_owned)
+          .unwrap_or(DEFAULT_AVATAR_PATH.to_owned())
 
         loading="lazy"
         class="mx-auto size-12"

--- a/src/ui/components/common/text_input.rs
+++ b/src/ui/components/common/text_input.rs
@@ -33,15 +33,15 @@ pub fn TextInput(
     <div class="relative w-full !mt-8">
       <input
         type=move || {
-            if input_type == InputType::Text || show_password.get() { "text" } else { "password" }
+          if input_type == InputType::Text || show_password.get() { "text" } else { "password" }
         }
 
         id=id
         class=move || {
-            format!(
-                "peer input w-full pe-10 input-bordered border-x-0 border-t-0 rounded-b-none border-b-2 focus:outline-none bg-base-300/50 {}",
-                validation_class.get(),
-            )
+          format!(
+            "peer input w-full pe-10 input-bordered border-x-0 border-t-0 rounded-b-none border-b-2 focus:outline-none bg-base-300/50 {}",
+            validation_class.get(),
+          )
         }
 
         placeholder=" "
@@ -57,7 +57,7 @@ pub fn TextInput(
         <button
           type="button"
           aria-label=move || {
-              if show_password.get() { tr!("hide-password") } else { tr!("show-password") }
+            if show_password.get() { tr!("hide-password") } else { tr!("show-password") }
           }
 
           class="btn btn-ghost btn-sm btn-circle absolute end-1 bottom-2 text-base-content"

--- a/src/ui/components/common/vote_buttons/vote_button.rs
+++ b/src/ui/components/common/vote_buttons/vote_button.rs
@@ -40,9 +40,7 @@ where
       <button
         type="submit"
         class=move || {
-            with!(
-                | is_voted | tw_merge!(vote_type.as_class(), (!is_voted).then_some("text-neutral"))
-            )
+          with!(| is_voted | tw_merge!(vote_type.as_class(), (!is_voted).then_some("text-neutral")))
         }
 
         title=title

--- a/src/ui/components/home/home_page.rs
+++ b/src/ui/components/home/home_page.rs
@@ -52,8 +52,8 @@ pub fn HomePage() -> impl IntoView {
   });
 
   view! {
-    <div class="flex mx-auto mt-4 mb-1 gap-6 h-fit sm:h-full">
-      <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit sm:h-full">
+    <div class="max-w-6xl mx-auto flex-auto flex items-stretch mt-4 mb-1 gap-6 overflow-y-auto">
+      <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit">
         <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 border-b-4 border-base-300 rounded-b-md">
           <h1 class="text-4xl font-bold text-nowrap">{move_tr!("home-feed")}</h1>
           {filter_bar}
@@ -67,7 +67,7 @@ pub fn HomePage() -> impl IntoView {
         </Suspense>
       </main>
 
-      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 overflow-y-auto min-h-0">
+      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 sticky top-0 h-fit">
         <Transition>
           <Unpack item=sidebar_data let:data>
             <Sidebar data=&data />

--- a/src/ui/components/home/home_page.rs
+++ b/src/ui/components/home/home_page.rs
@@ -52,9 +52,9 @@ pub fn HomePage() -> impl IntoView {
   });
 
   view! {
-    <div class="max-w-6xl mx-auto flex mt-4 mb-1 gap-6">
+    <div class="max-w-6xl mx-auto flex mb-1 gap-6">
       <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit">
-        <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 border-b-4 border-base-300 rounded-b-md">
+        <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 pt-4 border-b-4 border-base-300 rounded-b-md sticky top-0 z-10 bg-base-100">
           <h1 class="text-4xl font-bold text-nowrap">{move_tr!("home-feed")}</h1>
           {filter_bar}
         </div>

--- a/src/ui/components/home/home_page.rs
+++ b/src/ui/components/home/home_page.rs
@@ -52,7 +52,7 @@ pub fn HomePage() -> impl IntoView {
   });
 
   view! {
-    <div class="max-w-6xl mx-auto flex-auto flex items-stretch mt-4 mb-1 gap-6 overflow-y-auto">
+    <div class="max-w-6xl mx-auto flex mt-4 mb-1 gap-6">
       <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit">
         <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 border-b-4 border-base-300 rounded-b-md">
           <h1 class="text-4xl font-bold text-nowrap">{move_tr!("home-feed")}</h1>
@@ -67,7 +67,7 @@ pub fn HomePage() -> impl IntoView {
         </Suspense>
       </main>
 
-      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 sticky top-0 h-fit">
+      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 sticky top-6 h-fit">
         <Transition>
           <Unpack item=sidebar_data let:data>
             <Sidebar data=&data />

--- a/src/ui/components/home/home_page.rs
+++ b/src/ui/components/home/home_page.rs
@@ -52,7 +52,7 @@ pub fn HomePage() -> impl IntoView {
   });
 
   view! {
-    <div class="max-w-6xl mx-auto flex mb-1 gap-6">
+    <div class="max-w-screen-2xl mx-auto flex mb-1 gap-6">
       <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit">
         <div class="flex flex-wrap gap-y-2 gap-x-4 pb-1.5 pt-4 border-b-4 border-base-300 rounded-b-md sticky top-0 z-10 bg-base-100">
           <h1 class="text-4xl font-bold text-nowrap">{move_tr!("home-feed")}</h1>

--- a/src/ui/components/layouts/base_layout.rs
+++ b/src/ui/components/layouts/base_layout.rs
@@ -32,9 +32,7 @@ pub fn BaseLayout() -> impl IntoView {
               >
                 <SideNav />
               </nav>
-              <div class="flex-auto h-fit sm:h-auto max-w-6xl mx-auto">
-                <Outlet />
-              </div>
+              <Outlet />
             </div>
           </Unpack>
           <MobileNav />

--- a/src/ui/components/layouts/base_layout.rs
+++ b/src/ui/components/layouts/base_layout.rs
@@ -32,7 +32,9 @@ pub fn BaseLayout() -> impl IntoView {
               >
                 <SideNav />
               </nav>
-              <Outlet />
+              <div class="flex-auto overflow-y-auto">
+                <Outlet />
+              </div>
             </div>
           </Unpack>
           <MobileNav />

--- a/src/ui/components/layouts/base_layout/top_nav.rs
+++ b/src/ui/components/layouts/base_layout/top_nav.rs
@@ -39,7 +39,7 @@ fn InstanceName() -> impl IntoView {
 #[component]
 pub fn TopNav() -> impl IntoView {
   view! {
-    <nav class="navbar bg-gradient-to-br from-base-100 to-base-200 to-90% shadow-lg sm:px-7">
+    <nav class="navbar bg-gradient-to-br from-base-100 to-base-200 to-90% shadow-lg sm:px-7 z-20">
       <div class="navbar-start sm:hidden">
         <label for="mobile-drawer" aria-label="Open mobile drawer" class="btn btn-square btn-ghost">
           <Icon icon=IconType::Hamburger />

--- a/src/ui/components/layouts/base_layout/top_nav/auth_dropdown.rs
+++ b/src/ui/components/layouts/base_layout/top_nav/auth_dropdown.rs
@@ -39,19 +39,19 @@ pub fn AuthDropdown() -> impl IntoView {
           when=move || user_is_logged_in.get()
 
           fallback=move || {
-              view! {
-                <li>
-                  <A href="/login" class="btn btn-ghost transition duration-500">
-                    {move_tr!("login")}
-                  </A>
-                </li>
-                <li>
-                  <A href="/signup" class="btn btn-primary transition duration-500">
+            view! {
+              <li>
+                <A href="/login" class="btn btn-ghost transition duration-500">
+                  {move_tr!("login")}
+                </A>
+              </li>
+              <li>
+                <A href="/signup" class="btn btn-primary transition duration-500">
 
-                    {move_tr!("signup")}
-                  </A>
-                </li>
-              }
+                  {move_tr!("signup")}
+                </A>
+              </li>
+            }
           }
         >
 
@@ -66,12 +66,12 @@ pub fn AuthDropdown() -> impl IntoView {
                   <span class="text-nowrap leading-loose">
 
                     {
-                        let (name, display_name) = names
-                            .as_ref()
-                            .expect(
-                                "None case for my_user should be handled by ancestor Show component",
-                            );
-                        display_name.as_ref().unwrap_or(name)
+                      let (name, display_name) = names
+                        .as_ref()
+                        .expect(
+                          "None case for my_user should be handled by ancestor Show component",
+                        );
+                      display_name.as_ref().unwrap_or(name)
                     } " "
                     <Icon
                       class="align-bottom inline group-open:rotate-180 transition-transform"
@@ -84,14 +84,14 @@ pub fn AuthDropdown() -> impl IntoView {
                 <ul class="*:p-0 p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box">
                   <li>
                     <A href={
-                        let name = names
-                            .as_ref()
-                            .expect(
-                                "None case for my_user should be handled by ancestor Show component",
-                            )
-                            .0
-                            .as_str();
-                        format!("/u/{name}")
+                      let name = names
+                        .as_ref()
+                        .expect(
+                          "None case for my_user should be handled by ancestor Show component",
+                        )
+                        .0
+                        .as_str();
+                      format!("/u/{name}")
                     }>{move_tr!("profile")}</A>
                   </li>
                   <li>

--- a/src/ui/components/layouts/filter_bar_layout/listing_type_link.rs
+++ b/src/ui/components/layouts/filter_bar_layout/listing_type_link.rs
@@ -29,13 +29,13 @@ where
   view! {
     <A
       href=move || {
-          if disabled.get() {
-              String::from("javascript:void(0)")
-          } else {
-              let mut query = query.get();
-              query.insert(String::from("listingType"), link_listing_type.to_string());
-              query.to_query_string()
-          }
+        if disabled.get() {
+          String::from("javascript:void(0)")
+        } else {
+          let mut query = query.get();
+          query.insert(String::from("listingType"), link_listing_type.to_string());
+          query.to_query_string()
+        }
       }
 
       class="btn join-item aria-disabled:pointer-events-none aria-disabled:btn-disabled aria-selected:btn-active"

--- a/src/ui/components/layouts/filter_bar_layout/sort_type_link.rs
+++ b/src/ui/components/layouts/filter_bar_layout/sort_type_link.rs
@@ -15,9 +15,9 @@ where
 
       <A
         href=move || {
-            let mut query = query.get();
-            query.insert(String::from("sort"), link_sort_type.to_string());
-            query.to_query_string()
+          let mut query = query.get();
+          query.insert(String::from("sort"), link_sort_type.to_string());
+          query.to_query_string()
         }
 
         class="aria-selected:btn-active"

--- a/src/ui/components/login/login_page.rs
+++ b/src/ui/components/login/login_page.rs
@@ -4,7 +4,7 @@ use leptos::*;
 #[component]
 pub fn LoginPage() -> impl IntoView {
   view! {
-    <main class="mx-auto max-w-screen-md p-3">
+    <main class="max-w-screen-sm mx-auto max-w-screen-md p-3">
       <LoginForm />
     </main>
   }

--- a/src/ui/components/modals/report_modal.rs
+++ b/src/ui/components/modals/report_modal.rs
@@ -49,9 +49,9 @@ fn ReportForm(
       ": "
       <span>
         {move || {
-            with!(
-                |creator_name, creator_actor_id| create_user_apub_name(creator_name, creator_actor_id)
-            )
+          with!(
+            |creator_name, creator_actor_id| create_user_apub_name(creator_name, creator_actor_id)
+          )
         }}
       </span>
     </div>
@@ -112,23 +112,23 @@ pub fn ReportModal(
       _ref=dialog_ref
       class="modal"
       on:close=move |_| {
-          if let Some(form_ref) = form_ref.get() {
-              form_ref.reset();
-          }
+        if let Some(form_ref) = form_ref.get() {
+          form_ref.reset();
+        }
       }
     >
       <Show
         when=move || matches!(post_or_comment_id.get(), PostOrCommentId::Post(_))
         fallback=move || {
-            view! {
-              <ActionForm node_ref=form_ref action=report_comment_action class="modal-box">
-                <ReportForm
-                  creator_name=creator_name
-                  creator_actor_id=creator_actor_id
-                  post_or_comment_id=post_or_comment_id
-                />
-              </ActionForm>
-            }
+          view! {
+            <ActionForm node_ref=form_ref action=report_comment_action class="modal-box">
+              <ReportForm
+                creator_name=creator_name
+                creator_actor_id=creator_actor_id
+                post_or_comment_id=post_or_comment_id
+              />
+            </ActionForm>
+          }
         }
       >
         <ActionForm node_ref=form_ref action=report_post_action class="modal-box">

--- a/src/ui/components/post/post_listing.rs
+++ b/src/ui/components/post/post_listing.rs
@@ -158,11 +158,11 @@ pub fn PostListing<'a>(post_view: &'a PostView) -> impl IntoView {
       <Show
         when=move || is_on_post_page
         fallback=move || {
-            view! {
-              <h2 class="text-lg font-medium grid-in-title">
-                <A href=format!("/post/{id}")>{post_name}</A>
-              </h2>
-            }
+          view! {
+            <h2 class="text-lg font-medium grid-in-title">
+              <A href=format!("/post/{id}")>{post_name}</A>
+            </h2>
+          }
         }
       >
 
@@ -180,14 +180,14 @@ pub fn PostListing<'a>(post_view: &'a PostView) -> impl IntoView {
             {time_since_post}
           </div>
           {move || {
-              with!(
-                  |post_language| post_language.as_ref().map(|lang| view! {
+            with!(
+              |post_language| post_language.as_ref().map(|lang| view! {
                   <div class="text-xs badge badge-ghost gap-x-0.5">
                     <Icon icon=IconType::Language size=IconSize::Small />
                     {lang}
                   </div>
             })
-              )
+            )
           }}
         </div>
       </div>

--- a/src/ui/components/post/post_listings.rs
+++ b/src/ui/components/post/post_listings.rs
@@ -5,7 +5,7 @@ use leptos::*;
 #[component]
 pub fn PostListings(#[prop(into)] posts: MaybeSignal<Vec<PostView>>) -> impl IntoView {
   view! {
-    <ul class="divide-y divide-neutral sm:overflow-y-auto min-h-0 h-fit sm:h-full mb-14 sm:mb-4">
+    <ul class="divide-y divide-neutral min-h-0 h-fit sm:h-full mb-14 sm:mb-4">
       <For each=move || posts.get() key=|pv| pv.post.id let:pv>
         <li class="py-4 h-fit">
           <PostListing post_view=&pv />

--- a/src/ui/components/post/post_page.rs
+++ b/src/ui/components/post/post_page.rs
@@ -65,8 +65,8 @@ pub fn PostPage() -> impl IntoView {
   });
 
   view! {
-    <div class="flex mx-auto mt-4 mb-1 sm:gap-12 h-fit sm:h-full">
-      <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 sm:mx-0 h-fit sm:h-full">
+    <div class="max-w-screen-2xl mx-auto flex gap-6 flex mt-4 mb-1 sm:gap-12 h-fit">
+      <main class="basis-full lg:basis-13/20 xl:basis-7/10 flex flex-col mx-2.5 lg:mx-0 h-fit">
         <Transition>
           <Unpack item=post_resource let:res>
             <PostListing post_view=&res.post_view />
@@ -79,7 +79,7 @@ pub fn PostPage() -> impl IntoView {
       // </div>
       // </Unpack>
       </main>
-      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block sticky top-0 me-8 min-h-0">
+      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 sticky top-6 h-fit">
         <Transition>
           <Unpack item=sidebar_data let:data>
             <Sidebar data=&data />

--- a/src/ui/components/post/post_page.rs
+++ b/src/ui/components/post/post_page.rs
@@ -79,7 +79,7 @@ pub fn PostPage() -> impl IntoView {
       // </div>
       // </Unpack>
       </main>
-      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block me-8 overflow-y-auto min-h-0">
+      <aside class="hidden basis-7/20 xl:basis-3/10 lg:block sticky top-0 me-8 min-h-0">
         <Transition>
           <Unpack item=sidebar_data let:data>
             <Sidebar data=&data />


### PR DESCRIPTION
Tweaks how scrolling is handled somewhat. Before, the only way to scroll posts was to scroll inside the post listing: if you were using a screen large enough to have margin between the edges of the viewport and the part of the screen with posts, you would get the aggravating experience of not being able to scroll. This was particularly noticeable and annoying if you were trying to scroll on the page for a single post. Now, you can scroll up and sown as long as you are not in the side nav.

Also, the sidebar is no longer independently scrollable. It still sticks to the side of the screen like it did before.

## Before
[Screencast_20240919_214514.webm](https://github.com/user-attachments/assets/b6e86f7d-50f3-44af-a1e0-ddb6239286c3)

## After
[Screencast_20240919_214258.webm](https://github.com/user-attachments/assets/dc1ad3e0-fb48-46ac-91b3-2267cdaaaffc)
