### PR TITLE
Remove renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every weekend"],
-  "automerge": true
+  "schedule": ["every month on the first day of the month"]
 }


### PR DESCRIPTION
I can no longer run the app locally even though it worked fine after updating it to leptos 0.7. Looking at the log, it's all renovate changes. There is at least 1 breaking change that it merged without detecting that it's breaking: it upgraded Tailwind CSS to v4 in package.json even though there is a whole process that needs to be done to update it.

I'm removing automerge because it effectively keeps ripping the ground out from under my feet. I also made the update shedule more infrequent since I've been updating all the dependencies for each new PR I make. I think weekly makes more sense when the app is mostly feature complete.